### PR TITLE
styles: adapt inline-code and bullet styles

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -18,6 +18,31 @@ export default {
           950: "#1d2310",
         },
       },
+      typography(theme) {
+        return {
+          DEFAULT: {
+            css: {
+              "code::before": {
+                content: "none", // don’t generate the pseudo-element
+              },
+              "code::after": {
+                content: "none",
+              },
+              code: {
+                backgroundColor: theme("colors.stone.100"),
+                fontWeight: "normal",
+                fontSize: "85%",
+                borderRadius: theme("borderRadius.DEFAULT"),
+                paddingLeft: theme("spacing.1"),
+                paddingRight: theme("spacing.1"),
+                paddingTop: theme("spacing.1"),
+                paddingBottom: theme("spacing.1"),
+              },
+              "--tw-prose-bullets": theme("colors.gray.500"),
+            },
+          },
+        };
+      },
     },
   },
   plugins: [require("@tailwindcss/typography")],


### PR DESCRIPTION

<img width="218" alt="Screenshot 2023-11-05 at 11 49 18" src="https://github.com/Natel-Carolina/forestcatalogue/assets/6884094/ac946902-ee99-494a-baae-2531472abbbd">


- mimick github's inline-code styles, adjusted for contrast in our color scheme
- adjust bullets color for our color scheme